### PR TITLE
Fix fastmenu

### DIFF
--- a/resource/gamemenu.res
+++ b/resource/gamemenu.res
@@ -71,28 +71,6 @@
 		"OnlyInGame"	"1"
 	}
 	
-	////// fastmenu	
-	"HUD_ReloadButtom"
-	{
-		"label"			"K"
-		"Command"		"engine vgui_cache_res_files 0; hud_reloadscheme; vgui_cache_res_files 1"
-		"tooltip"		""
-		"OnlyInGame"	"0"
-	}
-	"HUDmat_antialias"
-	{
-		"label"			"J"
-		"Command"		"engine vgui_cache_res_files 0; incrementvar mat_antialias 1 2 1; hud_reloadscheme; vgui_cache_res_files 1"
-		"tooltip"		""
-		"OnlyInGame"	"0"
-	}
-	"VGUI"
-	{
-		"label"			"VGUI"
-		"command"		"engine sv_cheats 1; vgui_drawtree 1; vgui_drawfocus 1; vgui_drawtree_draw_selected 1"
-		"tooltip"		""
-		"OnlyInGame"	"0"
-	}
 	////// Ahud Sidemenu
 	////// Configuration
 	"Caption_SCW"

--- a/resource/ui/_mainmenuoverrideHUDEDITOR.res
+++ b/resource/ui/_mainmenuoverrideHUDEDITOR.res
@@ -1,130 +1,80 @@
 "Resource/UI/MainMenuOverride.res"
 {
-	"HUD_ReloadButtom"//for editors
+	"HUD_ReloadButton"	// for editors
 	{
-		"ControlName"		"EditablePanel"
-		"fieldName"			"HUD_ReloadButtom"
-		"xpos"				"r56"
-		"ypos"				"368"
-		"zpos"				"1"
-		"wide"				"21"
-		"tall"				"18"
-		"visible"			"1" //for editors
+		"ControlName"					"CExButton"
+		"fieldName"						"HUD_ReloadButton"
+		"xpos"							"r56"
+		"ypos"							"368"
+		"zpos"							"1"
+		"wide"							"21"
+		"tall"							"18"
+		"visible"						"1"
+		"enabled"						"1"
+		"labelText"						"K"
+		"font"							"AHUDicons13"
+		"textAlignment"					"center"
+		"command"						"engine vgui_cache_res_files 0; hud_reloadscheme; vgui_cache_res_files 1"
 
-		"SubButton"
-		{
-			"ControlName"				"CExImageButton"
-			"fieldName"					"SubButton"
-			"xpos"						"0"
-			"ypos"						"0"
-			"wide"						"21"
-			"tall"						"18"
-			"autoResize"				"0"
-			"pinCorner"					"3"
-			"tabPosition"				"0"
-			"font"						"AHUDicons13"
-			"textAlignment"				"center"
-			"dulltext"					"0"
-			"brighttext"				"0"
-			"default"					"1"
-			"use_proportional_insets"	"1"
-			"visible"					"1" //for editors
-
-	
-			"sound_depressed"			"UI/buttonclick.wav"
-			"sound_released"			"UI/buttonclickrelease.wav"
-		
-			"defaultFgColor_override"	"HudBlack"
-			"armedFgColor_override"		"HudPanelBorder"
-			"depressedFgColor_override"	"HudPanelBorder"
-			"border_default"			"NoBorder"
-			"border_armed"				"NoBorder"
-			"paintbackground"			"0"
-
-		}
+		"sound_depressed"				"UI/buttonclick.wav"
+		"sound_released"				"UI/buttonclickrelease.wav"
+		"defaultFgColor_override"		"HudBlack"
+		"armedFgColor_override"			"HudPanelBorder"
+		"depressedFgColor_override"		"HudPanelBorder"
+		"border_default"				"NoBorder"
+		"border_armed"					"NoBorder"
+		"paintbackground"				"0"
 	}
-	"HUDmat_antialias"//for editors
+
+	"HUDmat_antialias"	// for editors
 	{
-		"ControlName"		"EditablePanel"
-		"fieldName"			"HUDmat_antialias"
-		"xpos"				"r39"
-		"ypos"				"368"
-		"zpos"				"1"
-		"wide"				"21"
-		"tall"				"18"
-		"visible"			"1" //for editors
+		"ControlName"					"CExButton"
+		"fieldName"						"HUDmat_antialias"
+		"xpos"							"r39"
+		"ypos"							"368"
+		"zpos"							"1"
+		"wide"							"21"
+		"tall"							"18"
+		"visible"						"1"
+		"enabled"						"1"
+		"labelText"						"J"
+		"font"							"AHUDicons13"
+		"textAlignment"					"center"
+		"command"						"engine vgui_cache_res_files 0; incrementvar mat_antialias 1 2 1; hud_reloadscheme; vgui_cache_res_files 1"
 
-		"SubButton"
-		{
-			"ControlName"				"CExImageButton"
-			"fieldName"					"SubButton"
-			"xpos"						"0"
-			"ypos"						"0"
-			"wide"						"21"
-			"tall"						"18"
-			"autoResize"				"0"
-			"pinCorner"					"3"
-			"tabPosition"				"0"
-			"font"						"AHUDicons13"
-			"textAlignment"				"center"
-			"dulltext"					"0"
-			"brighttext"				"0"
-			"visible"					"1" //for editors
-			
-			"default"					"1"
-			"use_proportional_insets"	"1"
-	
-			"sound_depressed"			"UI/buttonclick.wav"
-			"sound_released"			"UI/buttonclickrelease.wav"
-		
-			"defaultFgColor_override"	"HudBlack"
-			"armedFgColor_override"		"HudPanelBorder"
-			"depressedFgColor_override"	"HudPanelBorder"
-			"border_default"			"NoBorder"
-			"border_armed"				"NoBorder"
-			"paintbackground"			"0"
-
-		}
+		"sound_depressed"				"UI/buttonclick.wav"
+		"sound_released"				"UI/buttonclickrelease.wav"
+		"defaultFgColor_override"		"HudBlack"
+		"armedFgColor_override"			"HudPanelBorder"
+		"depressedFgColor_override"		"HudPanelBorder"
+		"border_default"				"NoBorder"
+		"border_armed"					"NoBorder"
+		"paintbackground"				"0"
 	}
-	"VGUI"//for editors
+
+	"VGUI"	// for editors
 	{
-		"ControlName"		"EditablePanel"
-		"fieldName"			"VGUI"
-		"xpos"				"r93"
-		"ypos"				"365"
-		"zpos"				"1"
-		"wide"				"36"
-		"tall"				"20"	
-		"visible"			"1"	//for editors
+		"ControlName"					"CExButton"
+		"fieldName"						"VGUI"
+		"xpos"							"r93"
+		"ypos"							"365"
+		"zpos"							"1"
+		"wide"							"42"
+		"tall"							"25"
+		"visible"						"1"
+		"enabled"						"1"
+		"labelText"						"VGUI"
+		"font"							"aBold14"
+		"textAlignment"					"center"
+		"command"						"engine sv_cheats 1; vgui_drawtree 1; vgui_drawfocus 1; vgui_drawtree_draw_selected 1"
 
-		"SubButton"
-		{
-			"ControlName"				"CExImageButton"
-			"fieldName"					"SubButton"
-			"xpos"						"0"
-			"ypos"						"0"
-			"wide"						"42"
-			"tall"						"25"
-			"autoResize"				"0"
-			"pinCorner"					"3"
-			"tabPosition"				"0"
-			"font"						"aBold14"
-			"textAlignment"				"center"
-			"dulltext"					"1"
-			"brighttext"				"1"
-			"default"					"1"
-			"visible"					"1"	//for editors
-	
-			"sound_depressed"			"UI/buttonclick.wav"
-			"sound_released"			"UI/buttonclickrelease.wav"
-		
-			"defaultFgColor_override"	"HudBlack"
-			"armedFgColor_override"		"HudPanelBorder"
-			"depressedFgColor_override"	"HudPanelBorder"
-			"border_default"			"NoBorder"
-			"border_armed"				"NoBorder"
-			"paintbackground"			"0"
-
-		}
+		"sound_depressed"				"UI/buttonclick.wav"
+		"sound_released"				"UI/buttonclickrelease.wav"
+		"defaultFgColor_override"		"HudBlack"
+		"armedFgColor_override"			"HudPanelBorder"
+		"depressedFgColor_override"		"HudPanelBorder"
+		"border_default"				"NoBorder"
+		"border_armed"					"NoBorder"
+		"paintbackground"				"0"
 	}
 }


### PR DESCRIPTION
The fastmenu was removed by default in e19c2a6, but the entries were not removed from gamemenu.res, resulting in stray gamemenu buttons as seen [here](https://www.reddit.com/r/tf2/comments/1f0lx4m/comment/ljtbwag/).

This PR removes the stray gamemenu entries and converts the fastmenu buttons to independent CExButtons in `_mainmenuoverrideHUDEDITOR.res`
 